### PR TITLE
Fix the CLA link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-To get started, [sign the Contributor License Agreement](https://www.clahub.com/agreements/ID10T-Errors/signum-workshop-client).
+To get started, <a href="https://www.clahub.com/agreements/SignumCollective/signum-workshop-client">sign the Contributor License Agreement</a>.


### PR DESCRIPTION
I re-created the CLA in CLAHub because we changed the organization name, so I switched the link to the new CLA.

On a side note, we need to work on a rewrite of this.
